### PR TITLE
Add metadata fields to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ To build the code run
 ```
 npm run build
 ```
+
+To publish the package run
+```
+npm publish --access public
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naturescot/licensing-upload-utils",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "description": "Utilities to support integration of Licensing services with the File Upload application",
   "keywords": [
     "naturescot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naturescot/licensing-upload-utils",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Utilities to support integration of Licensing services with the File Upload application",
   "keywords": [
     "naturescot",
@@ -27,7 +27,9 @@
     "test": "npm run test:unit",
     "test:unit": "c8 --all --src \"src/**/*.ts\" --check-coverage --lines 1 ava --verbose"
   },
-  "author": "Dominic Lynch",
+  "contributors": [
+    "Dominic Lynch <dominic.lynch@nature.scot>"
+  ],
   "license": "(MIT OR OGL-UK-3.0 OR Apache-2.0)",
   "homepage": "https://github.com/Scottish-Natural-Heritage/naturescot-upload-utils",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export type {UploadConfig, UploadedFileMetadata, UploadFileConfig} from './upload-config';
 
-export type {TransferredFile} from './transfer';
+export type {TransferredFileInfo} from './transfer';
 
 export {getDefaultUploadConfig} from './upload-config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export type {UploadConfig, UploadedFileMetadata, UploadFileConfig} from './upload-config';
+
+export type {TransferredFile} from './transfer';
+
 export {getDefaultUploadConfig} from './upload-config';

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -1,13 +1,13 @@
 /**
- * @typedef {object} TransferredFile Represents a file that has been transferred to Objective Connect.
+ * @typedef {object} TransferredFileInfo Represents information on a file that has been transferred to Objective Connect.
  * @property {string} uuid  The identifier of the file in Objective Connect.
  * @property {string} fileName  The name of the transferred file.
- * @property {string} descriptor  A unique identifier describing the content of the file.
+ * @property {Record<string, string>} appMetadata  Metadata fields stored with the file in S3.
  */
-type TransferredFile = {
+type TransferredFileInfo = {
   uuid: string;
   fileName: string;
-  descriptor: string;
+  appMetadata?: Record<string, string>;
 };
 
-export type {TransferredFile};
+export type {TransferredFileInfo};

--- a/src/transfer.ts
+++ b/src/transfer.ts
@@ -1,0 +1,13 @@
+/**
+ * @typedef {object} TransferredFile Represents a file that has been transferred to Objective Connect.
+ * @property {string} uuid  The identifier of the file in Objective Connect.
+ * @property {string} fileName  The name of the transferred file.
+ * @property {string} descriptor  A unique identifier describing the content of the file.
+ */
+type TransferredFile = {
+  uuid: string;
+  fileName: string;
+  descriptor: string;
+};
+
+export type {TransferredFile};

--- a/src/upload-config.ts
+++ b/src/upload-config.ts
@@ -18,12 +18,14 @@ type UploadedFileMetadata = {
  * @property {string} hint  Text to display with more detail on what to upload.
  * @property {string} descriptor  Text to display describing content of file.
  * @property {UploadedFileMetadata} metadata  The metadata of the file once it has been uploaded.
+ * @property {Record<string, string>} appMetadata  Metadata fields to be stored with the file in S3.
  */
 type UploadFileConfig = {
   instruction: string;
   hint: string;
   descriptor: string;
   metadata?: UploadedFileMetadata;
+  appMetadata?: Record<string, string>;
 };
 
 /**


### PR DESCRIPTION
Added metadata fields to types `UploadFileConfig` & `TransferredFileInfo` so that application-specific data can be associated with each file stored in S3.