### PR TITLE
feature/1933-add-new-application-parameter

### DIFF
--- a/src/upload-config.ts
+++ b/src/upload-config.ts
@@ -44,6 +44,7 @@ type UploadConfig = {
   backUrl: string;
   returnUrl: string;
   sessionKey?: string;
+  isNewApplication?: boolean;
 };
 
 /**


### PR DESCRIPTION
This adds the parameter isNewApplication. This is used to clear the file upload cache during the first time an application redirects to file upload to prevent historic / irrelevant data being displayed.

Issue: Scottish-Natural-Heritage/Licensing#1933